### PR TITLE
Fix typo in VBoxManage command

### DIFF
--- a/vbox_inventory.py
+++ b/vbox_inventory.py
@@ -39,7 +39,7 @@ def get_hostvars(vmname):
     host vars.
     '''
     hostvars = copy(HOSTVAR_TEMPLATE)
-    cmd = Popen(['VboxManage', 'guestproperty', 'get', vmname,
+    cmd = Popen(['VBoxManage', 'guestproperty', 'get', vmname,
                  '/VirtualBox/GuestInfo/Net/0/V4/IP'], stdout=PIPE, stderr=PIPE)
     sout, serr = cmd.communicate()
     if serr != '' or cmd.returncode != 0:


### PR DESCRIPTION
`./vbox_inventory.py --list` throws an error `OSError: [Errno 2] No such file or directory` because of a typo in the `VBoxManage` command in `vbox_inventory.py`.